### PR TITLE
Fixed build failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 **__pycache__**
 *.tar
 *.tar.gz
+*.swp
 
 # Prevent certificates from getting checked in
 *.ca

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # BSD 3-Clause License
 #
-# Copyright 2022 Hewlett Packard Enterprise Development LP
+# Copyright [2022,2024] Hewlett Packard Enterprise Development LP
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -28,7 +28,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-FROM artifactory.algol60.net/docker.io/library/alpine:3.16 AS base
+FROM artifactory.algol60.net/docker.io/library/alpine:3.17 AS base
 
 COPY src/requirements.txt /app/requirements.txt
 
@@ -48,6 +48,7 @@ RUN set -ex \
         curl \
     && pip3 install --upgrade \
         pip \
+    && pip3 install \
         setuptools \
     && pip3 install wheel \
     && pip3 install -r /app/requirements.txt \


### PR DESCRIPTION


## Summary and Scope

This changes setuptools to not be upgraded.

The build was failing because of incompatabilities between the python libraries packaging and setuptools.

The packaging library is installed via an OS package, and so it cannot be upgraded by pip (uninstalled and then installed). The error given by pip is that it is a 'distutils installed project' and cannot accurately determine which files belong to it.

This may describe the root cause
https://github.com/pypa/setuptools/issues/4501

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMHMS-6243](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6243)


## Testing

### Tested on:

  * built on dev system
  * built in github

### Test description:

## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

